### PR TITLE
Don't crash when no dialog title is provided.

### DIFF
--- a/Source/SpiderEye.Mac/Dialogs/CocoaDialog.cs
+++ b/Source/SpiderEye.Mac/Dialogs/CocoaDialog.cs
@@ -18,7 +18,7 @@ namespace SpiderEye.Mac
             var window = NativeCast.To<CocoaWindow>(parent);
             var dialog = CreateDialog();
 
-            ObjC.Call(dialog.Handle, "setTitle:", NSString.Create(Title));
+            ObjC.Call(dialog.Handle, "setTitle:", NSString.Create(Title ?? string.Empty));
             ObjC.Call(dialog.Handle, "setCanCreateDirectories:", true);
 
             int result = dialog.Run(window);


### PR DESCRIPTION
The title property is non-nullable on the native side, so we cannot provide it a null `NSString` without crashing - the following is printed to the console:
```
*** Assertion failure in -[NSOpenPanel setTitle:], NSWindow.m:2610
```
The minimum reproduction was to do the following in the web page:
```js
const dialog = new OpenFileDialog();
const { file } = await dialog.showAsync();
```